### PR TITLE
Support Long Signal Names

### DIFF
--- a/internal/generate/compile.go
+++ b/internal/generate/compile.go
@@ -173,6 +173,9 @@ func (c *compiler) addMetadata() {
 				if def.AttributeName == "GenSigStartValue" {
 					sig.DefaultValue = int(def.IntValue)
 				}
+				if def.AttributeName == "SystemSignalLongSymbol" {
+					sig.LongName = def.StringValue
+				}
 			}
 		}
 	}

--- a/pkg/descriptor/signal.go
+++ b/pkg/descriptor/signal.go
@@ -8,8 +8,10 @@ import (
 
 // Signal describes a CAN signal.
 type Signal struct {
-	// Description of the signal.
+	// Name of the signal.
 	Name string
+	// LongName of the signal.
+	LongName string
 	// Start bit.
 	Start uint16
 	// Length in bits.


### PR DESCRIPTION
- Add LongName field in Signal object
- Set LongName from DBC (I can remove this from this PR if you prefer. I'm adding this just to show what the change would be in rbackbone, since we use a copy of this in rbackbone)